### PR TITLE
fixing vite.config so it works out of the box

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,29 +17,25 @@ export default defineConfig(({ mode }) => ({
         ),
     }),
   ],
-
-  resolve:
-    mode === "development"
-      ? {}
-      : {
-          alias: {
-            react: "https://unpkg.com/react@18.2.0/umd/react.development.js",
-            "react-dom":
-              "https://unpkg.com/react-dom@18.2.0/umd/react-dom.development.js",
-          },
-        },
   build: {
     lib: {
-      entry: "src/lib.tsx",
-      name: "wmc",
-      fileName: (format) => `cc.${format}.js`,
+      entry: "src/component/Component.tsx",
+      name: __COMPONENT_NAME__.replace(/-/g, "_").replace(/\s/g, "_"),
       formats: ["iife"],
+      fileName: (format) => `index.${format}.js`,
+    },
+    rollupOptions: {
+      external: ["react", "react-dom"],
+      output: {
+        globals: {
+          react: "React",
+          "react-dom": "ReactDOM",
+        },
+      },
     },
   },
   define: {
-    __COMPONENT_NAME__: JSON.stringify(
-      __COMPONENT_NAME__.replace(/-/g, "_").replace(/\s/g, "_")
-    ),
-    "process.env.NODE_ENV": '"production"',
+    __COMPONENT_NAME__: JSON.stringify(__COMPONENT_NAME__),
+    "process.env.NODE_ENV": JSON.stringify(mode),
   },
 }));


### PR DESCRIPTION
Currently, the code does not work as expected out of the box / when following the readme.md. Instead it presents a nearly blank page with "Output :" at the top.

These changes allow `npm run dev` to run as expected and give the developer output they can work with. 

Raised https://discord.com/channels/930051556043276338/1319655024258973797/1319655024258973797